### PR TITLE
Migration: Unique Constraints

### DIFF
--- a/lib/talents/org_user.ex
+++ b/lib/talents/org_user.ex
@@ -2,9 +2,10 @@ defmodule Talents.OrgUser do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @primary_key false
   schema "org_users" do
-    belongs_to :organization, Talents.Organization, foreign_key: :org_id
-    belongs_to :user, Talents.Accounts.User, foreign_key: :user_id
+    belongs_to :organization, Talents.Organization, foreign_key: :org_id, primary_key: true
+    belongs_to :user, Talents.Accounts.User, foreign_key: :user_id, primary_key: true
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/talents/user_talent.ex
+++ b/lib/talents/user_talent.ex
@@ -2,11 +2,12 @@ defmodule Talents.UserTalent do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @primary_key false
   schema "user_talents" do
     field :position, :integer
 
-    belongs_to :talent, Talents.Talent, foreign_key: :talent_id
-    belongs_to :user, Talents.Accounts.User, foreign_key: :user_id
+    belongs_to :talent, Talents.Talent, foreign_key: :talent_id, primary_key: true
+    belongs_to :user, Talents.Accounts.User, foreign_key: :user_id, primary_key: true
 
     timestamps(type: :utc_datetime)
   end

--- a/priv/repo/migrations/20251121162930_alter_org_user_table.exs
+++ b/priv/repo/migrations/20251121162930_alter_org_user_table.exs
@@ -2,6 +2,10 @@ defmodule Talents.Repo.Migrations.AlterOrgUserTable do
   use Ecto.Migration
 
   def change do
-    create unique_index(:org_users,[:org_id, :user_id])
+    create unique_index(:org_users, [:org_id, :user_id])
+
+    alter table(:org_users) do
+      remove :id
+    end
   end
 end

--- a/priv/repo/migrations/20251121163302_alter_user_talent_table.exs
+++ b/priv/repo/migrations/20251121163302_alter_user_talent_table.exs
@@ -2,6 +2,10 @@ defmodule Talents.Repo.Migrations.AlterUserTalentTable do
   use Ecto.Migration
 
   def change do
-    create unique_index(:user_talents,[:talent_id,:user_id])
+    create unique_index(:user_talents, [:talent_id, :user_id])
+
+    alter table(:user_talents) do
+      remove :id
+    end
   end
 end


### PR DESCRIPTION
### Why?
This PR enforces uniqueness in the N:N relationship tables.

### Description
This PR updates the database migrations to ensure that combinations in the many-to-many (N:N) tables are unique, in order to avoid duplicates.